### PR TITLE
feat(camera): Add auto-return to default position after inactivity

### DIFF
--- a/src/components/HeroCamera.jsx
+++ b/src/components/HeroCamera.jsx
@@ -1,30 +1,61 @@
 import { useFrame } from "@react-three/fiber"
-import { useRef } from "react" 
+import { useRef, useState } from "react"
 import { easing } from "maath"
-const HeroCamera = ({children,isMobile}) => {
-    const groupRef = useRef()
-    useFrame((state,delta) => {
-      
-      
-            easing.damp3(state.camera.position,[0,0,20],20,delta)
 
-         
-        
-
+const HeroCamera = ({ children, isMobile }) => {
+  const groupRef = useRef()
+  const lastInteractionRef = useRef(Date.now())
+  const returningRef = useRef(false)
+  const [returnDelay] = useState(5000) // Wait 5 seconds after last interaction
+  const pointerRef = useRef({ x: 0, y: 0 })
+  const currentPointerRef = useRef({ x: 0, y: 0 })
+ 
+  
+  useFrame((state, delta) => {
+    pointerRef.current.x = state.pointer.x
+    pointerRef.current.y = state.pointer.y
+    
+    if (currentPointerRef.current.y !== pointerRef.current.y || currentPointerRef.current.x !== pointerRef.current.x) {
+      // User is actively interacting - update last interaction time
+       lastInteractionRef.current = Date.now()
+      returningRef.current = false
+      currentPointerRef.current.x = pointerRef.current.x
+      currentPointerRef.current.y = pointerRef.current.y
+     
+      
+    }
+    
 
     
-        
+    // Calculate time since last interaction
+    const timeSinceInteraction = Date.now() - lastInteractionRef.current
+   
+    // Return to original position after delay if needed
+    if (!returningRef.current && 
+        timeSinceInteraction > returnDelay ) {
+      
+      returningRef.current = true
+ 
+    }
 
-        if(!isMobile) {
-          
-            easing.dampE(groupRef.current.rotation,[-state.pointer.y/3,state.pointer.x/5,0],0.25,delta)
-        }
-    })
+    if(returningRef.current) {
+        easing.damp3(state.camera.position, [0, 0, 20], 3, delta)
 
+    }
+
+    // Handle rotation for non-mobile
+    if (!isMobile) {
+      easing.dampE(
+        groupRef.current.rotation, 
+        [-state.pointer.y / 3, state.pointer.x / 5, 0], 
+        0.25, 
+        delta
+      )
+    }
+  })
 
   return (
-
-    <group ref={groupRef} scale={isMobile?1:1.3}>{children}</group>
+    <group ref={groupRef} scale={isMobile ? 1 : 1.3}>{children}</group>
   )
 }
 

--- a/src/sections/Hero.jsx
+++ b/src/sections/Hero.jsx
@@ -39,7 +39,7 @@ const Hero = () => {
                     </HeroCamera>
                     <OrbitControls
                         maxDistance={40}
-                        minDistance={5}
+                        minDistance={7}
                         maxPolarAngle={Math.PI / 2}
                      
                     />


### PR DESCRIPTION
Implement feature that returns 3D model view to default position after 5 seconds of user inactivity. This creates a cleaner presentation when users stop interacting with the model.

- Track last pointer interaction time with useRef
- Set 5-second inactivity threshold
- Use Maath easing for smooth transition back to default position
- Maintain responsive rotation for active interactions

Enhances user experience by automatically resetting the view when idle.